### PR TITLE
Publish SSL certs to k8s secrets

### DIFF
--- a/gke/pod/slackbot.yaml
+++ b/gke/pod/slackbot.yaml
@@ -14,7 +14,7 @@ spec:
       secret:
         secretName: google-dev
   containers:
-    - image: asia.gcr.io/builderscon-1248/slackbot:20160405.202610
+    - image: asia.gcr.io/builderscon-1248/slackbot:20160406.113602
       name: slackbot
       env:
         - name: SLACKBOT_API_TOKEN_FILE

--- a/slackbot/glide.lock
+++ b/slackbot/glide.lock
@@ -1,5 +1,5 @@
 hash: a653765dbd55ba91f87cec10591518bd6bfc88af3114b3f0657312355ae24330
-updated: 2016-04-05T20:24:05.230573298+09:00
+updated: 2016-04-06T11:32:33.45617931+09:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -93,7 +93,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/lestrrat/go-cloud-acmeagent
-  version: 62124fdcbe336e38c56e6372dd716a2f0397bb03
+  version: 5e20af40b861a467a695ce4215dc11e5dce7172f
   subpackages:
   - gcp
   - store
@@ -148,7 +148,7 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: 024ed629fd292398cfd43c9678a5bf004f7defdc
+  version: c2528b2dd8352441850638a8bb678c2ad056fd3e
   subpackages:
   - context
   - websocket
@@ -163,9 +163,9 @@ imports:
 - name: google.golang.org/api
   version: 77e7d383beb96054547729f49c372b3d01e196ff
   subpackages:
-  - compute/v1
   - dns/v1
   - storage/v1
+  - compute/v1
   - gensupport
   - googleapi
   - googleapi/internal/uritemplates
@@ -189,7 +189,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: d466437aa4adc35830964cffc5b5f262c63ddcb4
 - name: k8s.io/kubernetes
-  version: b8d000853edbfe3d0d9bcd85e8e511a98b6ac6af
+  version: 4f329516ae7312420577b10ee10005bbe17c87c8
   subpackages:
   - pkg/api
   - pkg/client/unversioned


### PR DESCRIPTION
As of k8s 1.2, the ingress submodule which is in use in GKE can handle TLS termination. To do this, the certs must be published to kubernetes as a `Secret` resource. update `go-cloud-acmeagent` to handle this, and apply the necessary changes
