### PR TITLE
Topic/issue 98

### DIFF
--- a/octav/handlers.go
+++ b/octav/handlers.go
@@ -534,7 +534,7 @@ func doCreateSession(ctx context.Context, w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.Decorate(tx, &v); err != nil {
-		httpError(w, `LookupSession`, http.StatusInternalServerError, err)
+		httpError(w, `CreateSession`, http.StatusInternalServerError, errors.Wrap(err)
 		return
 	}
 
@@ -1106,6 +1106,11 @@ func doListVenue(ctx context.Context, w http.ResponseWriter, r *http.Request, pa
 }
 
 func doLookupSession(ctx context.Context, w http.ResponseWriter, r *http.Request, payload model.LookupSessionRequest) {
+	if pdebug.Enabled {
+		g := pdebug.Marker("doLookupSession")
+		defer g.End()
+	}
+
 	tx, err := db.Begin()
 	if err != nil {
 		httpError(w, `LookupSession`, http.StatusInternalServerError, err)
@@ -1120,7 +1125,7 @@ func doLookupSession(ctx context.Context, w http.ResponseWriter, r *http.Request
 	}
 
 	s := service.Session{}
-	if err := s.Decorate(tx, &v); err != nil {
+	if err := errors.Wrap(s.Decorate(tx, &v), "failed to decorate session with associated data"); err != nil {
 		httpError(w, `LookupSession`, http.StatusInternalServerError, err)
 		return
 	}

--- a/octav/handlers.go
+++ b/octav/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lestrrat/go-apache-logformat"
 	"github.com/lestrrat/go-jsval"
 	"github.com/lestrrat/go-pdebug"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -534,7 +535,7 @@ func doCreateSession(ctx context.Context, w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.Decorate(tx, &v); err != nil {
-		httpError(w, `CreateSession`, http.StatusInternalServerError, errors.Wrap(err)
+		httpError(w, `CreateSession`, http.StatusInternalServerError, errors.Wrap(err))
 		return
 	}
 

--- a/octav/handlers.go
+++ b/octav/handlers.go
@@ -534,8 +534,8 @@ func doCreateSession(ctx context.Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if err := s.Decorate(tx, &v); err != nil {
-		httpError(w, `CreateSession`, http.StatusInternalServerError, errors.Wrap(err))
+	if err := errors.Wrap(s.Decorate(tx, &v), "failed to decorate session with associated data"); err != nil {
+		httpError(w, `CreateSession`, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/octav/service/session.go
+++ b/octav/service/session.go
@@ -198,7 +198,7 @@ func (v *Session) Decorate(tx *db.Tx, session *model.Session) error {
 	// session must be associated with a conference
 	if session.ConferenceID != "" {
 		conf := model.Conference{}
-		if err := conf.LoadByEID(tx, session.ConferenceID); err != nil {
+		if err := conf.Load(tx, session.ConferenceID); err != nil {
 			return errors.Wrap(err, "failed to load conference")
 		}
 		session.Conference = &conf
@@ -207,7 +207,7 @@ func (v *Session) Decorate(tx *db.Tx, session *model.Session) error {
 	// ... but not necessarily with a room
 	if session.RoomID != "" {
 		room := model.Room{}
-		if err := conf.LoadByEID(tx, session.RoomID); err != nil {
+		if err := room.Load(tx, session.RoomID); err != nil {
 			return errors.Wrap(err, "failed to load room")
 		}
 		session.Room = &room
@@ -215,7 +215,7 @@ func (v *Session) Decorate(tx *db.Tx, session *model.Session) error {
 
 	if session.SpeakerID != "" {
 		speaker := model.User{}
-		if err := speaker.LoadByEID(tx, session.SpeakerID); err != nil {
+		if err := speaker.Load(tx, session.SpeakerID); err != nil {
 			return errors.Wrapf(err, "failed to load speaker '%s'", session.SpeakerID)
 		}
 		session.Speaker = &speaker

--- a/octav/service/session.go
+++ b/octav/service/session.go
@@ -192,7 +192,7 @@ func (v *Session) LoadByConference(tx *db.Tx, vdbl *db.SessionList, cid string, 
 func (v *Session) Decorate(tx *db.Tx, session *model.Session) error {
 	// session must be associated with a conference
 	conf := model.Conference{}
-	if err := conf.Load(tx, session.ConferenceID); err != nil {
+	if err := conf.LoadByEID(tx, session.ConferenceID); err != nil {
 		return errors.Wrap(err, "failed to load conference")
 	}
 	session.Conference = &conf
@@ -200,14 +200,14 @@ func (v *Session) Decorate(tx *db.Tx, session *model.Session) error {
 	// ... but not necessarily with a room
 	if session.RoomID != "" {
 		room := model.Room{}
-		if err := conf.Load(tx, session.RoomID); err != nil {
+		if err := conf.LoadByEID(tx, session.RoomID); err != nil {
 			return errors.Wrap(err, "failed to load room")
 		}
 		session.Room = &room
 	}
 
 	speaker := model.User{}
-	if err := speaker.Load(tx, session.SpeakerID); err != nil {
+	if err := speaker.LoadByEID(tx, session.SpeakerID); err != nil {
 		return errors.Wrapf(err, "failed to load speaker '%s'", session.SpeakerID)
 	}
 	session.Speaker = &speaker

--- a/octav/service/session.go
+++ b/octav/service/session.go
@@ -208,7 +208,7 @@ func (v *Session) Decorate(tx *db.Tx, session *model.Session) error {
 
 	speaker := model.User{}
 	if err := speaker.Load(tx, session.SpeakerID); err != nil {
-		return errors.Wrap(err, "failed to load speaker")
+		return errors.Wrapf(err, "failed to load speaker '%s'", session.SpeakerID)
 	}
 	session.Speaker = &speaker
 

--- a/octav/sql/octav.sql
+++ b/octav/sql/octav.sql
@@ -100,9 +100,9 @@ CREATE TABLE conference_venues (
 CREATE TABLE sessions (
     oid INTEGER UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
     eid CHAR(64) CHARACTER SET latin1 NOT NULL,
-    conference_id CHAR(64) CHARACTER SET latin1 NOT NULL,
+    conference_id CHAR(64) CHARACTER SET latin1,
     room_id CHAR(64) CHARACTER SET latin1,
-    speaker_id CHAR(64) NOT NULL,
+    speaker_id CHAR(64) CHARACTER SET latin1,
     title TEXT NOT NULL,
     abstract TEXT,
     memo TEXT,
@@ -124,6 +124,8 @@ CREATE TABLE sessions (
     confirmed TINYINT(1) NOT NULL DEFAULT 0,
     created_on DATETIME NOT NULL,
     modified_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (speaker_id) REFERENCES users(eid) ON DELETE SET NULL,
+    FOREIGN KEY (conference_id) REFERENCES conferences(eid) ON DELETE SET NULL,
     UNIQUE KEY (eid),
     KEY(eid, conference_id, room_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
This and #99 mostly fixes #98 
- ~~#99 はLoadByEIDじゃなくてLoad使っててトホホ。~~
- スピーカーを消す、とかの動作は許容しないといけないが、その際のフォールバックをまだちゃんと制定してない。 see #100 
- カンファレンス情報やスピーカー情報が消えてもセッション本体は最後まで残るようにDBを変えた。
